### PR TITLE
feat: update for Swift 6.3 - use stable @section and @used attributes

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.10
+// swift-tools-version: 6.3
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -35,7 +35,7 @@ let package = Package(
             name: "ReerRouter",
             dependencies: ["RouterLauncher", "ReerRouterMacros", "SectionReader"],
             path: "Sources/ReerRouter",
-            swiftSettings: [.enableExperimentalFeature("SymbolLinkageMarkers")]
+            swiftSettings: []
         ),
         .target(name: "RouterLauncher")
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -38,6 +38,7 @@ let package = Package(
             swiftSettings: []
         ),
         .target(name: "RouterLauncher")
-    ]
+    ],
+    swiftLanguageModes: [.v5]
 )
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # ReerRouter
 App URL router for iOS (Swift only). Inspired by [URLNavigator](https://github.com/devxoul/URLNavigator).
 
-Swift 5.10 and later support @_used and @_section, allowing data to be written into sections. Combined with Swift Macros, this enables capabilities similar to various decoupling and registration information methods from the Objective-C era. This framework also supports registering routes in this manner.
+With the support of `@used` and `@section` (stable since Swift 6.3), data can be written into Mach-O sections. Combined with Swift Macros, this enables capabilities similar to various decoupling and registration methods from the Objective-C era. This framework also supports registering routes in this manner.
 
 Registering UIViewController
 ```
@@ -45,19 +45,17 @@ struct Foo {
     })
 }
 ```
-🟡 Currently, the @_used and @_section capabilities are still an experimental feature in Swift and need to be enabled through configuration settings. Please refer to the integration documentation for details.
-
 ## Example App
 To run the example project, clone the repo, and run `pod install` from the Example directory first.
 
 ## Requirements
-XCode 16.0 +
+Xcode 26.4 + (Swift 6.3+)
+
+> For older Xcode versions (16.0-26.3), please use version [2.2.8](https://github.com/reers/ReerRouter/releases/tag/2.2.8) which uses the experimental `@_section` and `@_used` attributes.
 
 iOS 13 +
 
-Swift 5.10
-
-swift-syntax 600.0.0
+swift-syntax 601.0.1+
 
 ## Installation
 
@@ -71,11 +69,11 @@ pod 'ReerRouter'
 As CocoaPods does not directly support the use of Swift Macros, the macro implementation can be compiled into a binary for use. The integration method is as follows. It's necessary to set s.pod_target_xcconfig in the components dependent on the router to load the binary plugin of the macro implementation:
 ```
 s.pod_target_xcconfig = {
-    'OTHER_SWIFT_FLAGS' => '-enable-experimental-feature SymbolLinkageMarkers -Xfrontend -load-plugin-executable -Xfrontend ${PODS_ROOT}/ReerRouter/MacroPlugin/ReerRouterMacros#ReerRouterMacros'
+    'OTHER_SWIFT_FLAGS' => '-Xfrontend -load-plugin-executable -Xfrontend ${PODS_ROOT}/ReerRouter/MacroPlugin/ReerRouterMacros#ReerRouterMacros'
   }
   
   s.user_target_xcconfig = {
-    'OTHER_SWIFT_FLAGS' => '-enable-experimental-feature SymbolLinkageMarkers -Xfrontend -load-plugin-executable -Xfrontend ${PODS_ROOT}/ReerRouter/MacroPlugin/ReerRouterMacros#ReerRouterMacros'
+    'OTHER_SWIFT_FLAGS' => '-Xfrontend -load-plugin-executable -Xfrontend ${PODS_ROOT}/ReerRouter/MacroPlugin/ReerRouterMacros#ReerRouterMacros'
   }
 ```
 Alternatively, if s.pod_target_xcconfig is not used, you can add the following script to the Podfile for unified processing:
@@ -94,11 +92,7 @@ post_install do |installer|
           swift_flags.concat(plugin_flag.split)
         end
 
-        # Add experimental feature flag for SymbolLinkageMarkers
-        symbol_linkage_flag = '-enable-experimental-feature SymbolLinkageMarkers'
 
-        unless swift_flags.join(' ').include?(symbol_linkage_flag)
-          swift_flags.concat(symbol_linkage_flag.split)
         end
 
         config.build_settings['OTHER_SWIFT_FLAGS'] = swift_flags
@@ -112,7 +106,6 @@ end
 <p>In your project's <strong>Build Settings</strong>, search for <code>User Script Sandboxing</code> and set <code>ENABLE_USER_SCRIPT_SANDBOXING</code> to <code>No</code>. This resolves CocoaPods script execution issues caused by Xcode's stricter sandbox restrictions.</p>
 
 ### Swift Package Manager
-For packages that need to depend on ReerRouter, it's necessary to enable the Swift experimental feature:
 ```
 // Package.swift
 let package = Package(
@@ -122,23 +115,18 @@ let package = Package(
         .library(name: "APackageDependOnReerRouter", targets: ["APackageDependOnReerRouter"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/reers/ReerRouter.git", from: "2.2.8")
+        .package(url: "https://github.com/reers/ReerRouter.git", from: "3.0.0")
     ],
     targets: [
         .target(
             name: "APackageDependOnReerRouter",
             dependencies: [
                 .product(name: "ReerRouter", package: "ReerRouter")
-            ],
-            // Add here to enable the experimental feature
-            swiftSettings:[.enableExperimentalFeature("SymbolLinkageMarkers")]
+            ]
         ),
     ]
 )
 ```
-In the main App Target's Build Settings, set to enable the experimental feature:
--enable-experimental-feature SymbolLinkageMarkers
-![CleanShot 2024-10-12 at 20 39 59@2x](https://github.com/user-attachments/assets/6a15fd27-61cf-4d55-974e-8f6006577527)
 
 ## Getting Started
 ### 1. Understanding `Route.Key`

--- a/README_CN.md
+++ b/README_CN.md
@@ -3,7 +3,7 @@
 # ReerRouter
 适用于iOS的应用程序URL路由器（仅限Swift）。受到[URLNavigator](https://github.com/devxoul/URLNavigator)的启发。
 
-Swift 5.10 之后, 支持了@_used @_section 可以将数据写入 section, 再结合 Swift Macro, 就可以实现 OC 时代各种解耦和的, 用于注册信息的能力了. 本框架也支持了以这种方式注册路由
+利用 `@used` 和 `@section`（Swift 6.3 起正式支持）可以将数据写入 Mach-O section, 再结合 Swift Macro, 就可以实现 OC 时代各种解耦和的, 用于注册信息的能力了. 本框架也支持了以这种方式注册路由
 
 注册 UIViewController
 ```
@@ -43,19 +43,19 @@ struct Foo {
     })
 }
 ```
-🟡 目前 @_used @_section 这个能力还是 Swift 的实验 Feature, 需要通过配置项开启, 详见接入文档.
+
 
 ## 示例应用程序
 要运行该示例项目，请克隆 repo，并首先在 Example 目录中运行 `pod install`。
 
 ## 要求
-XCode 16.0 +
+Xcode 26.4 + (Swift 6.3+)
+
+> 对于旧版 Xcode (16.0-26.3)，请使用 [2.2.8](https://github.com/reers/ReerRouter/releases/tag/2.2.8) 版本，该版本使用实验性的 `@_section` 和 `@_used` 属性。
 
 iOS 13 +
 
-Swift 5.10
-
-swift-syntax 600.0.0
+swift-syntax 601.0.1+
 
 ## 安装
 
@@ -69,11 +69,11 @@ pod 'ReerRouter'
 由于 CocoaPods 不支持直接使用 Swift Macro, 可以将宏实现编译为二进制提供使用, 接入方式如下, 需要在依赖路由的组件设置`s.pod_target_xcconfig`来加载宏实现的二进制插件:
 ```
 s.pod_target_xcconfig = {
-    'OTHER_SWIFT_FLAGS' => '-enable-experimental-feature SymbolLinkageMarkers -Xfrontend -load-plugin-executable -Xfrontend ${PODS_ROOT}/ReerRouter/MacroPlugin/ReerRouterMacros#ReerRouterMacros'
+    'OTHER_SWIFT_FLAGS' => '-Xfrontend -load-plugin-executable -Xfrontend ${PODS_ROOT}/ReerRouter/MacroPlugin/ReerRouterMacros#ReerRouterMacros'
   }
   
   s.user_target_xcconfig = {
-    'OTHER_SWIFT_FLAGS' => '-enable-experimental-feature SymbolLinkageMarkers -Xfrontend -load-plugin-executable -Xfrontend ${PODS_ROOT}/ReerRouter/MacroPlugin/ReerRouterMacros#ReerRouterMacros'
+    'OTHER_SWIFT_FLAGS' => '-Xfrontend -load-plugin-executable -Xfrontend ${PODS_ROOT}/ReerRouter/MacroPlugin/ReerRouterMacros#ReerRouterMacros'
   }
 ```
 或者, 如果不使用`s.pod_target_xcconfig`, 也可以在 podfile 中添加如下脚本统一处理:
@@ -92,11 +92,7 @@ post_install do |installer|
           swift_flags.concat(plugin_flag.split)
         end
 
-        # 添加 SymbolLinkageMarkers 实验性特性标志
-        symbol_linkage_flag = '-enable-experimental-feature SymbolLinkageMarkers'
 
-        unless swift_flags.join(' ').include?(symbol_linkage_flag)
-          swift_flags.concat(symbol_linkage_flag.split)
         end
 
         config.build_settings['OTHER_SWIFT_FLAGS'] = swift_flags
@@ -111,7 +107,6 @@ end
 
 
 ### Swift Package Manager
-对于要依赖 ReerRouter 的 package, 需要开启 swift 实验 feature
 ```
 // Package.swift
 let package = Package(
@@ -121,24 +116,18 @@ let package = Package(
         .library(name: "APackageDependOnReerRouter", targets: ["APackageDependOnReerRouter"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/reers/ReerRouter.git", from: "2.2.8")
+        .package(url: "https://github.com/reers/ReerRouter.git", from: "3.0.0")
     ],
     targets: [
         .target(
             name: "APackageDependOnReerRouter",
             dependencies: [
                 .product(name: "ReerRouter", package: "ReerRouter")
-            ],
-            // 此处添加开启实验 feature
-            swiftSettings:[.enableExperimentalFeature("SymbolLinkageMarkers")]
+            ]
         ),
     ]
 )
 ```
-
-在主App Target中 Build Settings设置开启实验feature:
--enable-experimental-feature SymbolLinkageMarkers
-![CleanShot 2024-10-12 at 20 39 59@2x](https://github.com/user-attachments/assets/6a15fd27-61cf-4d55-974e-8f6006577527)
 
 
 ## 开始使用

--- a/ReerRouterDemo/ReerRouterDemo.xcodeproj/project.pbxproj
+++ b/ReerRouterDemo/ReerRouterDemo.xcodeproj/project.pbxproj
@@ -168,7 +168,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				OTHER_SWIFT_FLAGS = "-enable-experimental-feature SymbolLinkageMarkers";
+				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.phoenix.ReerRouterDemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -198,7 +198,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				OTHER_SWIFT_FLAGS = "-enable-experimental-feature SymbolLinkageMarkers";
+				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.phoenix.ReerRouterDemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/Sources/ReerRouterMacros/ReerRouterMacros.swift
+++ b/Sources/ReerRouterMacros/ReerRouterMacros.swift
@@ -65,8 +65,8 @@ public struct WriteRouteActionToSectionMacro: DeclarationMacro {
         let hashLiteral = fnv1aHashLiteral(key)
         
         let declarationString = """
-            @_used 
-            @_section("__DATA,__rerouter_ac")
+            @used 
+            @section("__DATA,__rerouter_ac")
             \(staticString)let \(infoName): RouteActionInfo = (
                 \(hashLiteral),
                 { \(signature ?? "param in")
@@ -120,8 +120,8 @@ public struct WriteRouteVCToSectionMacro: ExtensionMacro {
         
         let extensionDecl: DeclSyntax = """
             extension \(raw: className): Routable {
-                @_used
-                @_section("__DATA,__rerouter_vc")
+                @used
+                @section("__DATA,__rerouter_vc")
                 private static let routableRegistration: RouteVCInfo = (
                     \(raw: hashLiteral),
                     { \(raw: className).self }


### PR DESCRIPTION
## Changes

- Replace `@_used` / `@_section` with stable `@used` / `@section` in macro expansion
- Update `swift-tools-version` to 6.3
- Remove `enableExperimentalFeature("SymbolLinkageMarkers")` from Package.swift
- Remove all experimental feature flags and descriptions from README (SPM & CocoaPods)
- Require Xcode 26.4+ (Swift 6.3+); older versions should use 2.2.8

## Testing

- `swift build` passed on Swift 6.3
