### PR TITLE
feat: Swift 6 strict concurrency support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -38,7 +38,6 @@ let package = Package(
             swiftSettings: []
         ),
         .target(name: "RouterLauncher")
-    ],
-    swiftLanguageModes: [.v5]
+    ]
 )
 

--- a/ReerRouterDemo/ReerRouterDemo.xcodeproj/project.pbxproj
+++ b/ReerRouterDemo/ReerRouterDemo.xcodeproj/project.pbxproj
@@ -172,7 +172,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.phoenix.ReerRouterDemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -202,7 +202,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.phoenix.ReerRouterDemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/ReerRouterDemo/ReerRouterDemo/RouteManager.swift
+++ b/ReerRouterDemo/ReerRouterDemo/RouteManager.swift
@@ -51,7 +51,7 @@ extension Router: @retroactive RouterConfigable {
 })
 
 final class RouteManager {
-    static let `default` = RouteManager()
+    nonisolated(unsafe) static let `default` = RouteManager()
     private init() {}
     
     var rootNavigationController: UINavigationController?

--- a/ReerRouterDemo/ReerRouterDemo/UserViewController.swift
+++ b/ReerRouterDemo/ReerRouterDemo/UserViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 import ReerRouter
 
 extension Route.Key {
-    static let userPage: Self = "user"
+    nonisolated(unsafe) static let userPage: Self = "user"
 }
 
 final class UserViewController: UIViewController, Routable {

--- a/Sources/ReerRouter/Define.swift
+++ b/Sources/ReerRouter/Define.swift
@@ -59,7 +59,7 @@ extension Route {
     
     public typealias Action = @convention(c) (_ params: Route.Param) -> Void
     
-    public typealias Completion = (_ success: Bool) -> Void
+    public typealias Completion = @Sendable (_ success: Bool) -> Void
     
     public typealias Interception = (_ params: Route.Param) -> Bool
 }
@@ -67,7 +67,7 @@ extension Route {
 public typealias UIViewControllerClassName = String
 
 /// Global instance of the Router.
-public let AppRouter = Router.shared
+nonisolated(unsafe) public let AppRouter = Router.shared
 
 
 // MARK: - Routable

--- a/Sources/ReerRouter/Param.swift
+++ b/Sources/ReerRouter/Param.swift
@@ -12,7 +12,7 @@ extension Route {
     
     /// Generate by open url and user info dictionary,
     /// and it will be passed to the `init(param: Route.Param)` of the routable UIViewController.
-    public class Param: NSObject {
+    public class Param: NSObject, @unchecked Sendable {
         public let sourceURL: URL
         
         public var scheme: String {
@@ -60,7 +60,7 @@ extension Route {
             return !allParams[Route.noAnimationKey].bool
         }
         
-        public static var `default` = Param(url: URL(string: "\(Route.defaultScheme)://")!)
+        nonisolated(unsafe) public static var `default` = Param(url: URL(string: "\(Route.defaultScheme)://")!)
     }
 }
 #endif

--- a/Sources/ReerRouter/Router.swift
+++ b/Sources/ReerRouter/Router.swift
@@ -37,7 +37,7 @@ import SectionReader
 ///
 open class Router {
     /// Global singleton instance.
-    public static let shared = Router()
+    nonisolated(unsafe) public static let shared = Router()
     
     private init() {}
     


### PR DESCRIPTION
## Summary
Add Swift 6 strict concurrency support while maintaining Swift 5.x compatibility.

## Changes

### Library
- **Package.swift**: Remove `swiftLanguageModes(.v5)` to use Swift 6 default
- **Router.swift**: Add `nonisolated(unsafe)` to `Router.shared` singleton
- **Define.swift**: Add `nonisolated(unsafe)` to `AppRouter`; Make `Route.Completion` `@Sendable`
- **Param.swift**: Add `nonisolated(unsafe)` to `Param.default`; Make `Param` `@unchecked Sendable`

### Demo
- Update `SWIFT_VERSION` from 5.0 to 6.0
- Fix demo singletons with `nonisolated(unsafe)` annotations

## Backward Compatibility
All changes are additive isolation annotations that are ignored in Swift 5.x, ensuring existing projects continue to work.

## Testing
- [x] `swift build` passes with Swift 6.3
- [x] Demo compiles and runs in Xcode with Swift 6 language mode
